### PR TITLE
Public clearfeedbackmessages function

### DIFF
--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -462,6 +462,11 @@ namespace uWebshop.Domain.Businesslogic
 			return handleObjectList;
 		}
 
+        public void ClearFeedbackMessagesExternal()
+        {
+            ClearFeedbackMessages();
+        }
+
 		internal static void ClearFeedbackMessages()
 		{
 			Session.Remove(Constants.BasketActionResult);


### PR DESCRIPTION
Hey Arnold,

Dit is mijn quickfix voor het message probleem, misschien kun je er wat mee en weet jij nog een betere oplossing.

Nu gebruik ik deze functie in m'n view nadat de messages ingeladen worden.

De ClearFeedbackMessages() werd niet aangeroepen bij het beindigen van een request, dit zorgt ervoor dat de sessiedata blijft bestaan.
