### PR TITLE
Ensure shipping values are added to the order XML

### DIFF
--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -1766,31 +1766,31 @@ namespace uWebshop.Domain.Businesslogic
 			
             IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
 
-		    if (customerDataType == CustomerDatatypes.Shipping)
-		    {
-                var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+			if (customerDataType == CustomerDatatypes.Shipping)
+			{
+				var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
 
-			    if (customerIsShippingKey != null)
-			    {
-				    var customerIsShippingValue = requestParameters[customerIsShippingKey];
+				if (customerIsShippingKey != null)
+				{
+					var customerIsShippingValue = requestParameters[customerIsShippingKey];
 
-				    if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
-				    {
-					    var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
+					if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
+					{
+						var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
 
-					    if (!shippingFields.Any()) return handleObject;
-					    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-				    }
-			    }
-		        else
-		        {
-				    var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
+						if (!shippingFields.Any()) return handleObject;
+						order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+					}
+				}
+				else
+				{
+					var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
 
-				    if (!shippingFields.Any()) return handleObject;
+					if (!shippingFields.Any()) return handleObject;
 
-                    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-		        }
-		    }
+					order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+				}
+			}
             
 
 			order.Save();

--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -1763,22 +1763,35 @@ namespace uWebshop.Domain.Businesslogic
 				handleObject.Messages = result;
 				return handleObject;
 			}
-			IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
+			
+            IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
 
-			var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+		    if (customerDataType == CustomerDatatypes.Shipping)
+		    {
+                var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
 
-			if (customerIsShippingKey != null)
-			{
-				var customerIsShippingValue = requestParameters[customerIsShippingKey];
+			    if (customerIsShippingKey != null)
+			    {
+				    var customerIsShippingValue = requestParameters[customerIsShippingKey];
 
-				if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
-				{
-					var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
+				    if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
+				    {
+					    var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
 
-					if (!shippingFields.Any()) return handleObject;
-					order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-				}
-			}
+					    if (!shippingFields.Any()) return handleObject;
+					    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+				    }
+			    }
+		        else
+		        {
+				    var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
+
+				    if (!shippingFields.Any()) return handleObject;
+
+                    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+		        }
+		    }
+            
 
 			order.Save();
 


### PR DESCRIPTION
Apologies if this is messy even if it is small - it's my first pull request.

The original code did not record the shipping values in the order XML. It would record the shipping values if the "customerIsShipping" param was supplied but in this case it would use the customer params instead.

I've added:

 - Another clause to allow for the shipping values to be recorded;
 - Wrapped both clauses in another clause to ensure that it is only carried out for CustomerDataType.Shipping