### PR TITLE
Addition of OrderStatus check so that anonymous wishlists can be retrieved

### DIFF
--- a/Core/uWebshop.Domain/API/Customers.cs
+++ b/Core/uWebshop.Domain/API/Customers.cs
@@ -234,7 +234,7 @@ namespace uWebshop.API
 				{
 					var wishlist = Orders.GetOrder(wishGuid);
 
-					if (wishlist.Status == OrderStatus.Wishlist)
+					if (wishlist != null && wishlist.Status == OrderStatus.Wishlist)
 					{
 						return (IWishlist)wishlist;
 					}

--- a/Core/uWebshop.Domain/API/Orders.cs
+++ b/Core/uWebshop.Domain/API/Orders.cs
@@ -49,7 +49,7 @@ namespace uWebshop.API
 
 			var membershipUser = Membership.GetUser();
           
-		     if (IO.Container.Resolve<ICMSApplication>().IsBackendUserAuthenticated || membershipUser != null && membershipUser.UserName == order.CustomerInfo.LoginName || UwebshopRequest.Current.PaymentProvider != null || OrderHelper.IsCompletedOrderWithinValidLifetime(order))
+		     if (IO.Container.Resolve<ICMSApplication>().IsBackendUserAuthenticated || membershipUser != null && membershipUser.UserName == order.CustomerInfo.LoginName || UwebshopRequest.Current.PaymentProvider != null || OrderHelper.IsCompletedOrderWithinValidLifetime(order) || order.Status == OrderStatus.Wishlist)
             {
                 return CreateBasketFromOrderInfo(order);
             }

--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -1766,31 +1766,31 @@ namespace uWebshop.Domain.Businesslogic
 			
             IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
 
-		    if (customerDataType == CustomerDatatypes.Shipping)
-		    {
-                var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+			if (customerDataType == CustomerDatatypes.Shipping)
+			{
+				var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
 
-			    if (customerIsShippingKey != null)
-			    {
-				    var customerIsShippingValue = requestParameters[customerIsShippingKey];
+				if (customerIsShippingKey != null)
+				{
+					var customerIsShippingValue = requestParameters[customerIsShippingKey];
 
-				    if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
-				    {
-					    var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
+					if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
+					{
+						var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
 
-					    if (!shippingFields.Any()) return handleObject;
-					    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-				    }
-			    }
-		        else
-		        {
-				    var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
+						if (!shippingFields.Any()) return handleObject;
+						order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+					}
+				}
+				else
+				{
+					var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
 
-				    if (!shippingFields.Any()) return handleObject;
+					if (!shippingFields.Any()) return handleObject;
 
-                    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-		        }
-		    }
+					order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+				}
+			}
             
 
 			order.Save();

--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -1763,22 +1763,35 @@ namespace uWebshop.Domain.Businesslogic
 				handleObject.Messages = result;
 				return handleObject;
 			}
-			IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
+			
+            IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
 
-			var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+		    if (customerDataType == CustomerDatatypes.Shipping)
+		    {
+                var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
 
-			if (customerIsShippingKey != null)
-			{
-				var customerIsShippingValue = requestParameters[customerIsShippingKey];
+			    if (customerIsShippingKey != null)
+			    {
+				    var customerIsShippingValue = requestParameters[customerIsShippingKey];
 
-				if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
-				{
-					var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
+				    if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
+				    {
+					    var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
 
-					if (!shippingFields.Any()) return handleObject;
-					order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-				}
-			}
+					    if (!shippingFields.Any()) return handleObject;
+					    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+				    }
+			    }
+		        else
+		        {
+				    var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
+
+				    if (!shippingFields.Any()) return handleObject;
+
+                    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+		        }
+		    }
+            
 
 			order.Save();
 

--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -1766,31 +1766,31 @@ namespace uWebshop.Domain.Businesslogic
 			
             IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
 
-			if (customerDataType == CustomerDatatypes.Shipping)
-			{
-				var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+		    if (customerDataType == CustomerDatatypes.Shipping)
+		    {
+                var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
 
-				if (customerIsShippingKey != null)
-				{
-					var customerIsShippingValue = requestParameters[customerIsShippingKey];
+			    if (customerIsShippingKey != null)
+			    {
+				    var customerIsShippingValue = requestParameters[customerIsShippingKey];
 
-					if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
-					{
-						var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
+				    if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
+				    {
+					    var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
 
-						if (!shippingFields.Any()) return handleObject;
-						order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-					}
-				}
-				else
-				{
-					var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
+					    if (!shippingFields.Any()) return handleObject;
+					    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+				    }
+			    }
+		        else
+		        {
+				    var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
 
-					if (!shippingFields.Any()) return handleObject;
+				    if (!shippingFields.Any()) return handleObject;
 
-					order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-				}
-			}
+                    order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
+		        }
+		    }
             
 
 			order.Save();

--- a/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
+++ b/Core/uWebshop.Domain/Businesslogic/BasketRequestHandler.cs
@@ -1763,35 +1763,22 @@ namespace uWebshop.Domain.Businesslogic
 				handleObject.Messages = result;
 				return handleObject;
 			}
-			
-            IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
+			IO.Container.Resolve<IOrderUpdatingService>().AddCustomerFields(order, fields, customerDataType);
 
-			if (customerDataType == CustomerDatatypes.Shipping)
+			var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+
+			if (customerIsShippingKey != null)
 			{
-				var customerIsShippingKey = requestParameters.AllKeys.FirstOrDefault(x => x.ToLower() == "customerisshipping"); //requestParameters["customerIsShipping"];
+				var customerIsShippingValue = requestParameters[customerIsShippingKey];
 
-				if (customerIsShippingKey != null)
+				if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
 				{
-					var customerIsShippingValue = requestParameters[customerIsShippingKey];
-
-					if (customerIsShippingValue != null && (customerIsShippingValue.ToLower() == "customerisshipping" || customerIsShippingValue.ToLower() == "true" || customerIsShippingValue.ToLower() == "on" || customerIsShippingValue == "1"))
-					{
-						var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
-
-						if (!shippingFields.Any()) return handleObject;
-						order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
-					}
-				}
-				else
-				{
-					var shippingFields = stringCollection.ToDictionary(s => s, s => requestParameters[s]);
+					var shippingFields = stringCollection.ToDictionary(s => s.Replace("customer", "shipping"), s => requestParameters[s]);
 
 					if (!shippingFields.Any()) return handleObject;
-
 					order.AddCustomerFields(shippingFields, CustomerDatatypes.Shipping);
 				}
 			}
-            
 
 			order.Save();
 

--- a/Umbraco/uWebshop.Umbraco/Services/UmbracoApplicationCacheManager.cs
+++ b/Umbraco/uWebshop.Umbraco/Services/UmbracoApplicationCacheManager.cs
@@ -16,6 +16,7 @@ namespace uWebshop.Umbraco.Services
 	{
 		private readonly IProductService _productService;
 		private readonly IProductVariantService _productVariantService;
+		private readonly IProductVariantGroupService _productVariantGroupService;
 		private readonly ICategoryService _categoryService;
 		private readonly IOrderDiscountService _orderDiscountService;
 		private readonly IProductDiscountService _productDiscountService;
@@ -33,13 +34,14 @@ namespace uWebshop.Umbraco.Services
 
 		private readonly bool _manageUmbracoXMLCacheWhenLoadBalanced;
 
-		public UmbracoApplicationCacheManagingService(IProductService productService, IProductVariantService productVariantService, ICategoryService categoryService, 
+		public UmbracoApplicationCacheManagingService(IProductService productService, IProductVariantService productVariantService, IProductVariantGroupService productVariantGroupService, ICategoryService categoryService, 
 			IOrderDiscountService orderDiscountService, IProductDiscountService productDiscountService,
             IProductRepository productRepository, ICategoryRepository categoryRepository, IProductVariantGroupRepository productVariantGroupRepository, IProductVariantRepository productVariantRepository,
 			IStoreService storeService, IApplicationCacheService applicationCacheService)//, IShippingProviderService shippingProviderService, IPaymentProviderService paymentProviderService)
 		{
 			_productService = productService;
 			_productVariantService = productVariantService;
+			_productVariantGroupService = productVariantGroupService;
 			_categoryService = categoryService;
 			_orderDiscountService = orderDiscountService;
 			_productDiscountService = productDiscountService;
@@ -198,6 +200,7 @@ namespace uWebshop.Umbraco.Services
 		{
 			_productService.FullResetCache();
 			_productVariantService.FullResetCache();
+			_productVariantGroupService.FullResetCache();
 			_categoryService.FullResetCache();
 			_orderDiscountService.FullResetCache();
 			_productDiscountService.FullResetCache();


### PR DESCRIPTION
This pull request is in relation to issue #16 where anonymous wishlists cannot be retrieved by calling `Customers.GetWishlist()`.

I have added a condition to check whether the `Order` being requested is a wishlist. Without this condition anonymous wishlists will never be returned causing a null reference exception. I have also added a nullreference exception for completeness.